### PR TITLE
fix: calendar onSelect error. convert onSelect to onDayClick

### DIFF
--- a/src/components/RegistrationForm/index.tsx
+++ b/src/components/RegistrationForm/index.tsx
@@ -229,7 +229,7 @@ const RegistrationForm = ({ setUserName, setIsSubmitted, setIsSubmitSuccessful, 
                           <Calendar
                             mode="single"
                             selected={field.value}
-                            onSelect={field.onChange}
+                            onDayClick={field.onChange}
                             disabled={(date) =>
                               date > new Date() || date < new Date("1900-01-01")
                             }


### PR DESCRIPTION
AS-IS
  - Form에 등록일을 기본값으로 new Date()로 지정
  - Calendar Component에 onSelect={fiedl.onChange} 설정

Calendar를 눌러서 날짜를 누르면 Form에서 인식하지 못하는 오류 발생

TO-BE
  - Calendar에서 onSelect={field.onChange} -> onDayClick={field.onChange}로 변경